### PR TITLE
Add map tab and rotation quality check

### DIFF
--- a/imu_csv_export_v2.py
+++ b/imu_csv_export_v2.py
@@ -501,3 +501,10 @@ def export_csv_smart_v2(self, gps_df: pd.DataFrame | None = None) -> None:
     from PyQt5.QtWidgets import QMessageBox
     QMessageBox.information(self, "Export fertig",
                             f"CSV + JSON liegen in:\n{dest}")
+
+    sel_topic = self.cmb_map.currentText()
+    rot_path = dest / f"{sel_topic.strip('/').replace('/', '__')}_{bag_root.stem}__imu_v1.json"
+    rot = None
+    if rot_path.exists():
+        rot = json.loads(rot_path.read_text()).get("vehicle_rot_mat")
+    self.map_widget.set_data(gps_df, rot)

--- a/map_widget.py
+++ b/map_widget.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+import tempfile
+import json
+
+import folium
+from PyQt5.QtWebEngineWidgets import QWebEngineView
+from PyQt5.QtCore import QUrl
+
+class MapWidget(QWebEngineView):
+    """Zeigt OSM-Karte mit GPS-Track + Heading-Pfeilen."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._tmp_html = Path(tempfile.mkstemp(suffix=".html")[1])
+        self._map = folium.Map(tiles="OpenStreetMap")
+        self._drawn = False
+        self._refresh()
+
+    def set_data(self, gps_df, rot_mat):
+        if gps_df is None or gps_df.empty:
+            self._map = folium.Map(tiles="OpenStreetMap")
+            self._refresh()
+            return
+
+        lat0 = gps_df["lat"].iloc[0]
+        lon0 = gps_df["lon"].iloc[0]
+        self._map = folium.Map(location=[lat0, lon0], zoom_start=16, tiles="OpenStreetMap")
+
+        folium.PolyLine(gps_df[["lat", "lon"]].values, color="blue", weight=2).add_to(self._map)
+
+        if rot_mat is not None:
+            import numpy as np
+            R = np.array(rot_mat)
+            fwd = R @ np.array([1, 0, 0])
+            heading_deg = (np.degrees(np.arctan2(fwd[1], fwd[0])) + 360) % 360
+            folium.Marker(
+                location=[lat0, lon0],
+                icon=folium.plugins.BeautifyIcon(
+                    icon_shape="arrow",
+                    border_color="#d35400",
+                    border_width=2,
+                    text_color="#d35400",
+                    icon_rotate=heading_deg,
+                ),
+                tooltip=f"Heading ≈ {heading_deg:.1f}°",
+            ).add_to(self._map)
+
+        self._refresh()
+
+    def _refresh(self):
+        self._map.save(self._tmp_html)
+        self.setUrl(QUrl.fromLocalFile(str(self._tmp_html)))


### PR DESCRIPTION
## Summary
- add new `MapWidget` to display GPS track and heading
- integrate `MapWidget` in main window as a new tab
- allow topic selection for the map
- update map automatically after export or topic switch
- simplify rotation quality check

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683b42a21b58832d8ecab8a0fc461f37