### PR TITLE
Add rotation tuning dialog and map visualization tweaks

### DIFF
--- a/map_widget.py
+++ b/map_widget.py
@@ -6,7 +6,8 @@ import folium
 from folium.plugins import BeautifyIcon
 from geopy.distance import geodesic
 from PyQt5.QtWebEngineWidgets import QWebEngineView
-from PyQt5.QtCore import QUrl
+from PyQt5.QtCore import QUrl, Qt
+from PyQt5.QtWidgets import QMenu
 
 class MapWidget(QWebEngineView):
     """Zeigt OSM-Karte mit GPS-Track + Heading-Pfeilen."""
@@ -16,9 +17,13 @@ class MapWidget(QWebEngineView):
         self._tmp_html = Path(tempfile.mkstemp(suffix=".html")[1])
         self._map = folium.Map(tiles="OpenStreetMap")
         self._drawn = False
+        self._gps_df = None
+        self._rot_mat = None
         self._refresh()
 
-    def set_data(self, gps_df, rot_mat):
+    def set_data(self, gps_df, rot_mat, every_n=200):
+        self._gps_df = gps_df
+        self._rot_mat = rot_mat
         if gps_df is None or gps_df.empty:
             self._map = folium.Map(tiles="OpenStreetMap")
             self._refresh()
@@ -33,48 +38,33 @@ class MapWidget(QWebEngineView):
         if rot_mat is not None:
             import numpy as np
             R = np.array(rot_mat)
-            fwd = R @ np.array([1, 0, 0])
-            heading_deg = (np.degrees(np.arctan2(fwd[1], fwd[0])) + 360) % 360
-            folium.Marker(
-                location=[lat0, lon0],
-                icon=BeautifyIcon(
-                    icon_shape="arrow",
-                    border_color="#d35400",
-                    border_width=2,
-                    text_color="#d35400",
-                    icon_rotate=heading_deg,
-                ),
-                tooltip=f"Heading \u2248 {heading_deg:.1f}\xb0",
-            ).add_to(self._map)
-
-            # --- Länge der Pfeile auf der Karte (Meter) ---
-            L_FWD = 10  # Meter
-            L_LEFT = 5   # Meter
-
-            # ► Endpunkte berechnen
-            pt_fwd = geodesic(meters=L_FWD).destination((lat0, lon0), heading_deg)
-            pt_left = geodesic(meters=L_LEFT).destination(
-                (lat0, lon0), (heading_deg + 90) % 360
-            )
-
-            # ► X-Achse (rot)
-            folium.PolyLine(
-                [[lat0, lon0], [pt_fwd.latitude, pt_fwd.longitude]],
-                color="red",
-                weight=3,
-                tooltip="Sensor X",
-            ).add_to(self._map)
-
-            # ► Y-Achse (grün)
-            folium.PolyLine(
-                [[lat0, lon0], [pt_left.latitude, pt_left.longitude]],
-                color="green",
-                weight=3,
-                tooltip="Sensor Y",
-            ).add_to(self._map)
+            idxs = range(0, len(gps_df), every_n) if len(gps_df) > every_n else [0]
+            for j in idxs:
+                lat, lon = gps_df.loc[j, ["lat", "lon"]]
+                fwd = R @ np.array([1, 0, 0])
+                heading = (np.degrees(np.arctan2(fwd[1], fwd[0])) + 360) % 360
+                self._draw_arrow(lat, lon, heading, L=6)
 
         self._refresh()
+
+    def _draw_arrow(self, lat, lon, heading, L=6):
+        pt = geodesic(meters=L).destination((lat, lon), heading)
+        folium.PolyLine(
+            [[lat, lon], [pt.latitude, pt.longitude]],
+            color="orange", weight=2
+        ).add_to(self._map)
 
     def _refresh(self):
         self._map.save(self._tmp_html)
         self.setUrl(QUrl.fromLocalFile(str(self._tmp_html)))
+
+    def mousePressEvent(self, ev):
+        if ev.button() == Qt.RightButton:
+            m = QMenu(self)
+            m.addAction(
+                "Sensor→Vehicle-Mtx ausblenden",
+                lambda: self.set_data(self._gps_df, None),
+            )
+            m.exec(ev.globalPos())
+        else:
+            super().mousePressEvent(ev)


### PR DESCRIPTION
## Summary
- allow configuring rotation parameters via new `ParamDialog`
- add checkbox to display corrected accel data
- plot raw, corrected and vehicle axes together
- draw multiple orientation arrows on the map and add context menu
- pass config to rotation utilities for filter tuning

## Testing
- `python -m py_compile main_gui_v2.py map_widget.py rotation_utils.py imu_csv_export_v2.py`

------
https://chatgpt.com/codex/tasks/task_e_683bef6fe2b0832da847b9161dd3d581