### PR TITLE
Add QSettings-based persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ from the **View** menu. Comfort and health weighting can now be selected via
 **IMU Settings → Comfort/Health mode weighting**. The map tab shows an
 interactive OpenStreetMap powered by *folium*. Current settings can be stored
 and later restored using **File → Save settings…** and **File → Load settings…**.
+Window geometry and active topics are automatically preserved between sessions
+via Qt's `QSettings`.


### PR DESCRIPTION
## Summary
- persist window geometry and active topics across runs using `QSettings`
- mention new persistence in README

## Testing
- `python3 -m py_compile main_gui_v2.py imu_csv_export_v2.py iso_weighting.py`

------
https://chatgpt.com/codex/tasks/task_e_683d49c21e08832d956dfdb5b5d75ad4