### PR TITLE
Fix progress dialog cancel state

### DIFF
--- a/progress_ui.py
+++ b/progress_ui.py
@@ -32,11 +32,16 @@ class ProgressWindow(QDialog):
         self.lst.setCurrentRow(0)
         vbox.addWidget(self.lst, stretch=1)
 
+        self._aborted = False
         self.btn_abort = QPushButton("Abbrechen")
-        self.btn_abort.clicked.connect(self.reject)
+        self.btn_abort.clicked.connect(self._on_abort)
         vbox.addWidget(self.btn_abort)
 
         self.show()
+
+    def _on_abort(self) -> None:
+        self._aborted = True
+        self.reject()
 
     def advance(self, text: str | None = None) -> bool:
         """Fortschritt +1 Step.  Rückgabe: True = nicht abgebrochen."""
@@ -66,4 +71,4 @@ class ProgressWindow(QDialog):
         QApplication.processEvents()
 
     def wasCanceled(self) -> bool:
-        return self.result() == QDialog.Rejected
+        return self._aborted


### PR DESCRIPTION
## Summary
- ensure `ProgressWindow.wasCanceled()` only returns `True` when abort button is clicked

## Testing
- `python -m py_compile progress_ui.py main_gui_v2.py iso_weighting.py map_widget.py imu_csv_export_v2.py`

------
https://chatgpt.com/codex/tasks/task_e_683d7e8c8cb8832db36b6222a1924b8e