### PR TITLE
Enable NumPy frame playback and 3‑D point clouds

### DIFF
--- a/main_gui_v2.py
+++ b/main_gui_v2.py
@@ -1217,25 +1217,18 @@ class MainWindow(QMainWindow):
         pre = float(self.tab_vpc.spn_pre.value())
         post = float(self.tab_vpc.spn_post.value())
         times = np.arange(t_peak - pre, t_peak + post, 0.1)
-        video_frames: list[QImage] = []
-        pc_frames: list[QImage] = []
+        video_frames: list[np.ndarray] = []
+        pc_frames: list[np.ndarray] = []
         for t in times:
-            txt = f"Video t={t:.1f}s"
-            img = QImage(320, 240, QImage.Format_RGB32)
-            img.fill(Qt.white)
-            p = QPainter(img)
-            p.drawText(img.rect(), Qt.AlignCenter, txt)
-            p.end()
+            val = int(255 * (t - times[0]) / max(times[-1] - times[0], 0.1))
+            img = np.full((240, 320, 3), val, dtype=np.uint8)
             video_frames.append(img)
 
-            pc = QImage(320, 240, QImage.Format_RGB32)
-            pc.fill(Qt.lightGray)
-            p = QPainter(pc)
-            p.drawText(pc.rect(), Qt.AlignCenter, f"PC t={t:.1f}s")
-            p.end()
-            pc_frames.append(pc)
+            pts = np.random.normal(size=(500, 3)).astype(np.float32)
+            pts[:, 2] += 0.1 * t
+            pc_frames.append(pts)
 
-        self.tab_vpc.load_frames(video_frames, pc_frames)
+        self.tab_vpc.load_arrays(video_frames, pc_frames)
         self.tabs.setCurrentIndex(2)
         self.tab_vpc.play()
 

--- a/videopc_widget.py
+++ b/videopc_widget.py
@@ -1,20 +1,25 @@
 # -*- coding: utf-8 -*-
-"""Simple placeholder widgets for synchronized video and point cloud playback.
+"""Video and point cloud playback widget.
 
-This module provides a ``VideoPointCloudTab`` widget that contains two columns
-for a video frame and a point cloud view. The layout roughly matches the
-requested design but does not implement full 3-D rendering or synchronization.
-It merely demonstrates how the GUI could be structured.
+The :class:`VideoPointCloudTab` now supports displaying video frames from
+NumPy arrays via :func:`show_frame` and rendering 3-D point clouds with
+``pyqtgraph``.  Point size can be adjusted interactively.
 """
 
 from __future__ import annotations
 
 
 from PyQt5.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QDoubleSpinBox
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel,
+    QPushButton, QDoubleSpinBox
 )
 from PyQt5.QtCore import Qt, QTimer
 from PyQt5.QtGui import QPixmap, QImage
+
+import numpy as np
+
+import pyqtgraph as pg
+from pyqtgraph.opengl import GLViewWidget, GLScatterPlotItem
 
 
 class VideoPointCloudTab(QWidget):
@@ -60,14 +65,29 @@ class VideoPointCloudTab(QWidget):
 
         # ------------------------------ Point cloud column
         pcol = QVBoxLayout()
-        self.lbl_pc = QLabel("Point Cloud View")
-        self.lbl_pc.setAlignment(Qt.AlignCenter)
-        self.lbl_pc.setMinimumSize(320, 240)
-        pcol.addWidget(self.lbl_pc, stretch=1)
+        self.gl_view = GLViewWidget()
+        self.gl_view.setMinimumSize(320, 240)
+        self.gl_view.opts["distance"] = 5
+        pcol.addWidget(self.gl_view, stretch=1)
+        self.lbl_placeholder = QLabel("Point Cloud View")
+        self.lbl_placeholder.setAlignment(Qt.AlignCenter)
+        self.lbl_placeholder.hide()
+        pcol.addWidget(self.lbl_placeholder, stretch=1)
         hbox.addLayout(pcol, stretch=1)
+
+        ctrl.addWidget(QLabel("Point size:"))
+        self.spn_size = QDoubleSpinBox()
+        self.spn_size.setRange(1.0, 20.0)
+        self.spn_size.setValue(5.0)
+        self.spn_size.valueChanged.connect(self.update_point_size)
+        ctrl.addWidget(self.spn_size)
 
         self.video_frames: list[QImage] = []
         self.pc_frames: list[QImage] = []
+        self.img_arrays: list[np.ndarray] = []
+        self.pc_arrays: list[np.ndarray] = []
+        self.scatter_item: GLScatterPlotItem | None = None
+        self.point_size = self.spn_size.value()
         self.sync_index = 0
         self.timer = QTimer(self)
         self.timer.timeout.connect(self._next_frame)
@@ -90,7 +110,9 @@ class VideoPointCloudTab(QWidget):
 
     def show_pointcloud_placeholder(self, text: str) -> None:
         """Display placeholder text in the point cloud view."""
-        self.lbl_pc.setText(text)
+        self.gl_view.setVisible(False)
+        self.lbl_placeholder.setText(text)
+        self.lbl_placeholder.setVisible(True)
 
     # ------------------------------ playback ------------------------------
     def load_frames(self, video: list[QImage], pc: list[QImage]) -> None:
@@ -102,8 +124,19 @@ class VideoPointCloudTab(QWidget):
         if pc:
             self.show_pc_frame(pc[0])
 
+    def load_arrays(self, images: list[np.ndarray], pcs: list[np.ndarray]) -> None:
+        """Load NumPy arrays for video frames and point clouds."""
+        self.img_arrays = images
+        self.pc_arrays = pcs
+        self.sync_index = 0
+        if images:
+            self.show_frame(0)
+        if pcs:
+            self.draw_scatter(pcs[0])
+
     def play(self) -> None:
-        if not self.video_frames:
+        """Start playback if any frames are available."""
+        if not (self.video_frames or self.img_arrays):
             return
         self.timer.start(100)
 
@@ -118,15 +151,63 @@ class VideoPointCloudTab(QWidget):
             self.show_pc_frame(self.pc_frames[0])
         self.play()
 
+    def show_frame(self, i: int) -> None:
+        if not self.img_arrays:
+            return
+        i = max(0, min(i, len(self.img_arrays) - 1))
+        arr = self.img_arrays[i]
+        if arr.ndim == 2:
+            h, w = arr.shape
+            fmt = QImage.Format_Grayscale8
+            bytes_per_line = w
+        else:
+            h, w, ch = arr.shape
+            fmt = QImage.Format_RGB888 if ch == 3 else QImage.Format_RGBA8888
+            bytes_per_line = ch * w
+        qimg = QImage(arr.tobytes(), w, h, bytes_per_line, fmt)
+        qimg = qimg.copy()
+        self.show_video_frame(qimg)
+
+    def draw_scatter(self, pts: np.ndarray) -> None:
+        if pts.size == 0:
+            return
+        self.gl_view.setVisible(True)
+        self.lbl_placeholder.setVisible(False)
+        z = pts[:, 2]
+        zmin = float(z.min())
+        rng = float(z.max() - zmin) or 1.0
+        norm = (z - zmin) / rng
+        colors = np.column_stack((norm, np.zeros_like(norm), 1 - norm, np.ones_like(norm)))
+        if self.scatter_item is None:
+            self.scatter_item = GLScatterPlotItem(pos=pts, color=colors, size=self.point_size)
+            self.gl_view.addItem(self.scatter_item)
+        else:
+            self.scatter_item.setData(pos=pts, color=colors, size=self.point_size)
+
+    def update_point_size(self, val: float) -> None:
+        self.point_size = val
+        if self.scatter_item is not None:
+            self.scatter_item.setData(size=val)
+
     def _next_frame(self) -> None:
-        if self.sync_index >= len(self.video_frames):
+        if self.sync_index >= max(len(self.video_frames), len(self.img_arrays)):
             self.pause()
             return
-        self.show_video_frame(self.video_frames[self.sync_index])
+        if self.video_frames:
+            self.show_video_frame(self.video_frames[self.sync_index])
+        elif self.img_arrays:
+            self.show_frame(self.sync_index)
         if self.pc_frames:
             idx = min(self.sync_index, len(self.pc_frames) - 1)
             self.show_pc_frame(self.pc_frames[idx])
+        elif self.pc_arrays:
+            idx = min(self.sync_index, len(self.pc_arrays) - 1)
+            self.draw_scatter(self.pc_arrays[idx])
         self.sync_index += 1
 
     def show_pc_frame(self, img: QImage) -> None:
-        self.lbl_pc.setPixmap(QPixmap.fromImage(img))
+        # legacy method for QImage based frames
+        self.lbl_placeholder.setVisible(False)
+        self.gl_view.setVisible(False)
+        self.lbl_placeholder.setPixmap(QPixmap.fromImage(img))
+        self.lbl_placeholder.setVisible(True)


### PR DESCRIPTION
## Summary
- add GLViewWidget based point cloud viewer
- allow playback of NumPy video frames
- let user change point size
- adapt peak video preview to use new APIs
- fix playback not starting when using NumPy arrays

## Testing
- `python -m py_compile videopc_widget.py main_gui_v2.py`


------
https://chatgpt.com/codex/tasks/task_e_683da9b82af0832d922f7d838daa3352