### PR TITLE
Improve peak defaults and video playback

### DIFF
--- a/iso_weighting.py
+++ b/iso_weighting.py
@@ -98,7 +98,7 @@ def exponential_running_rms(x: np.ndarray, fs: float, tau: float = 1.0) -> np.nd
 
 def calc_awv(ax: np.ndarray, ay: np.ndarray, az: np.ndarray,
              fs: float, comfort: bool = True,
-             peak_height: float = 3.19, peak_dist: float = 0.0,
+             peak_height: float = 3.19, peak_dist: float = 1.5,
              max_peak: bool = False) -> dict[str, np.ndarray | float]:
     """Calculate weighted vibration values for three axes.
 


### PR DESCRIPTION
## Summary
- update default `peak_dist` value in ISO weighting
- set default peak distance to 1.5 s in GUI
- show only ISO weighted axes by default
- crop video/point cloud playback around selected peak using frame timestamps

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_683dbf893f70832d832de1545b4c91c9