### PR TITLE
Fix PCD export directories

### DIFF
--- a/imu_csv_export_v2.py
+++ b/imu_csv_export_v2.py
@@ -278,6 +278,7 @@ def _save_pcd(path: Path, pts: np.ndarray) -> None:
         f"POINTS {len(pts)}\n"
         "DATA ascii\n"
     )
+    path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "w") as f:
         f.write(header)
         np.savetxt(f, pts, fmt="%.3f")


### PR DESCRIPTION
## Summary
- ensure directories for PCD files exist when exporting peaks

## Testing
- `python3 -m py_compile main_gui_v2.py imu_csv_export_v2.py progress_ui.py map_widget.py videopc_widget.py iso_weighting.py`

------
https://chatgpt.com/codex/tasks/task_e_684126bd3658832da36270cfec53d8e3