### PR TITLE
Add statistics visualization tab

### DIFF
--- a/stats_tab.py
+++ b/stats_tab.py
@@ -42,7 +42,7 @@ class StatsTab(QWidget):
         vbox.addLayout(hl)
 
         # ----- plot -----
-        self.fig = Figure(figsize=(5, 4))
+        self.fig = Figure(figsize=(6, 5))
         self.canvas = FigureCanvas(self.fig)
         vbox.addWidget(self.canvas, stretch=1)
 
@@ -105,17 +105,30 @@ class StatsTab(QWidget):
         grp_vals = [grp_counts.get(lbl, 0) for lbl in all_labels]
         cols = [self.colors.get(lbl, "#808080") for lbl in all_labels]
 
+        total_dp = sum(dp_vals)
+
+        # scale unknown bar to half height for visual clarity
+        dp_display = dp_vals[:]
+        grp_display = grp_vals[:]
+        if self.unknown_name in all_labels:
+            idx = all_labels.index(self.unknown_name)
+            dp_display[idx] = dp_display[idx] / 2
+            grp_display[idx] = grp_display[idx] / 2
+
         x = range(len(all_labels))
         width = 0.4
 
         ax1 = self.fig.add_subplot(211)
-        ax1.bar([i - width/2 for i in x], dp_vals, width=width, label="Data Points", color=cols, alpha=0.9)
-        ax1.bar([i + width/2 for i in x], grp_vals, width=width, label="Groups", color="black", alpha=0.6)
+        ax1.bar([i - width/2 for i in x], dp_display, width=width, label="Data Points", color=cols, alpha=0.9)
+        ax1.bar([i + width/2 for i in x], grp_display, width=width, label="Groups", color="black", alpha=0.6)
 
-        for i, val in enumerate(dp_vals):
-            ax1.text(i - width/2, val + max(dp_vals) * 0.01, str(val), ha="center", va="bottom", fontsize=8)
-        for i, val in enumerate(grp_vals):
-            ax1.text(i + width/2, val + max(grp_vals) * 0.01, str(val), ha="center", va="bottom", fontsize=8, color="black")
+        for i, (orig, disp) in enumerate(zip(dp_vals, dp_display)):
+            ax1.text(i - width/2, disp + max(dp_display) * 0.01, str(orig), ha="center", va="bottom", fontsize=8)
+        for i, (orig, disp) in enumerate(zip(grp_vals, grp_display)):
+            ax1.text(i + width/2, disp + max(grp_display) * 0.01, str(orig), ha="center", va="bottom", fontsize=8, color="black")
+
+        ax1.text(0.99, 0.98, f"Total: {total_dp}", transform=ax1.transAxes,
+                 ha="right", va="top", fontsize=9)
 
         ax1.set_xticks(x)
         ax1.set_xticklabels(all_labels, rotation=45, ha="right", fontsize=8)
@@ -125,9 +138,11 @@ class StatsTab(QWidget):
 
         ax2 = self.fig.add_subplot(212)
         if sum(dp_vals) > 0:
-            ax2.pie(dp_vals, labels=all_labels, colors=cols, autopct="%1.1f%%", startangle=140)
+            ax2.pie(dp_vals, labels=all_labels, colors=cols, autopct="%1.1f%%", startangle=140, radius=1.2)
+            ax2.set_aspect('equal')
         else:
             ax2.text(0.5, 0.5, "No data", ha="center", va="center")
+            ax2.set_aspect('equal')
         ax2.set_title("Share of Labeled Data Points")
 
         self.fig.tight_layout()

--- a/stats_tab.py
+++ b/stats_tab.py
@@ -21,7 +21,7 @@ from matplotlib.figure import Figure
 
 
 class StatsTab(QWidget):
-    """Display class statistics from exported CSV files."""
+    """Display total and labeled data point counts per class from exported CSV files."""
 
     def __init__(self, colors: dict[str, str], unknown_name: str, parent=None) -> None:
         super().__init__(parent)
@@ -66,8 +66,8 @@ class StatsTab(QWidget):
         self.lbl_path.setText(str(folder))
         csv_files = list(folder.rglob("*.csv"))
         csv_files = [f for f in csv_files if not f.name.endswith("_track.csv")]
-        dp_counts = defaultdict(int)
-        grp_counts = defaultdict(int)
+        total_counts = defaultdict(int)
+        labeled_counts = defaultdict(int)
         for csv in csv_files:
             try:
                 df = pd.read_csv(csv)
@@ -77,39 +77,40 @@ class StatsTab(QWidget):
                 continue
             labels = df["label_name"].fillna(self.unknown_name)
             for lbl, cnt in labels.value_counts().items():
-                dp_counts[str(lbl)] += int(cnt)
-            seg_id = (labels != labels.shift()).cumsum()
-            for _, grp in labels.groupby(seg_id):
-                grp_counts[str(grp.iloc[0])] += 1
-        self._plot_stats(dp_counts, grp_counts)
+                total_counts[str(lbl)] += int(cnt)
+            labeled = labels[labels != self.unknown_name]
+            for lbl, cnt in labeled.value_counts().items():
+                labeled_counts[str(lbl)] += int(cnt)
+        self._plot_stats(total_counts, labeled_counts)
 
-    def _plot_stats(self, dp_counts: dict[str, int], grp_counts: dict[str, int]) -> None:
+    def _plot_stats(self, total_counts: dict[str, int], labeled_counts: dict[str, int]) -> None:
         self.fig.clear()
-        if not dp_counts and not grp_counts:
+        if not total_counts:
             self.canvas.draw()
             return
 
-        all_labels = sorted(set(dp_counts) | set(grp_counts))
-        dp_vals = [dp_counts.get(lbl, 0) for lbl in all_labels]
-        grp_vals = [grp_counts.get(lbl, 0) for lbl in all_labels]
+        all_labels = sorted(set(total_counts) | set(labeled_counts))
+        total_vals = [total_counts.get(lbl, 0) for lbl in all_labels]
+        labeled_vals = [labeled_counts.get(lbl, 0) for lbl in all_labels]
         cols = [self.colors.get(lbl, "#808080") for lbl in all_labels]
 
         ax1 = self.fig.add_subplot(211)
         x = range(len(all_labels))
-        ax1.bar(x, dp_vals, label="Data Points", color=cols, alpha=0.7)
-        ax1.bar(x, grp_vals, label="Groups", color="black", alpha=0.2)
-        ax1.set_xticks(x)
+        w = 0.4
+        ax1.bar([i - w/2 for i in x], total_vals, width=w, label="All Points", color=cols, alpha=0.5)
+        ax1.bar([i + w/2 for i in x], labeled_vals, width=w, label="Labeled Points", color=cols, alpha=0.9)
+        ax1.set_xticks(list(x))
         ax1.set_xticklabels(all_labels, rotation=45)
         ax1.set_ylabel("Count")
-        ax1.set_title("Data Points (solid) vs. Groups (gray)")
+        ax1.set_title("All vs. Labeled Points per Class")
         ax1.legend()
 
         ax2 = self.fig.add_subplot(212)
-        if sum(dp_vals) > 0:
-            ax2.pie(dp_vals, labels=all_labels, colors=cols, autopct="%1.1f%%", startangle=140)
+        if sum(labeled_vals) > 0:
+            ax2.pie(labeled_vals, labels=all_labels, colors=cols, autopct="%1.1f%%", startangle=140)
         else:
-            ax2.text(0.5, 0.5, "No data", ha="center", va="center")
-        ax2.set_title("Share of Data Points per Class")
+            ax2.text(0.5, 0.5, "No labeled data", ha="center", va="center")
+        ax2.set_title("Share of Labeled Data Points per Class")
 
         self.fig.tight_layout()
         self.canvas.draw()

--- a/stats_tab.py
+++ b/stats_tab.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+
+import pandas as pd
+from PyQt5.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QLabel, QFileDialog,
+)
+
+try:
+    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+except Exception:
+    from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.figure import Figure
+
+
+class StatsTab(QWidget):
+    """Display class statistics from exported CSV files."""
+
+    def __init__(self, colors: dict[str, str], unknown_name: str, parent=None) -> None:
+        super().__init__(parent)
+        vbox = QVBoxLayout(self)
+
+        # ----- control bar -----
+        hl = QHBoxLayout()
+        hl.addWidget(QLabel("Folder:"))
+        self.lbl_path = QLabel("-")
+        hl.addWidget(self.lbl_path)
+        self.btn_browse = QPushButton("Browse…")
+        self.btn_browse.clicked.connect(self._browse)
+        hl.addWidget(self.btn_browse)
+        hl.addStretch()
+        vbox.addLayout(hl)
+
+        # ----- plot -----
+        self.fig = Figure(figsize=(5, 4))
+        self.canvas = FigureCanvas(self.fig)
+        vbox.addWidget(self.canvas, stretch=1)
+
+        self.colors = colors
+        self.unknown_name = unknown_name
+
+    def _browse(self) -> None:
+        path = QFileDialog.getExistingDirectory(self, "Select CSV Folder")
+        if path:
+            self.load_folder(path)
+
+    def load_folder(self, folder: str | Path) -> None:
+        folder = Path(folder)
+        self.lbl_path.setText(str(folder))
+        csv_files = [p for p in folder.glob("*.csv") if not p.name.endswith("_track.csv")]
+        dp_counts = defaultdict(int)
+        grp_counts = defaultdict(int)
+        for csv in csv_files:
+            try:
+                df = pd.read_csv(csv)
+            except Exception:
+                continue
+            if "label_name" not in df.columns:
+                continue
+            labels = df["label_name"].fillna(self.unknown_name)
+            for lbl, cnt in labels.value_counts().items():
+                dp_counts[str(lbl)] += int(cnt)
+            seg_id = (labels != labels.shift()).cumsum()
+            for _, grp in labels.groupby(seg_id):
+                grp_counts[str(grp.iloc[0])] += 1
+        self._plot_stats(dp_counts, grp_counts)
+
+    def _plot_stats(self, dp_counts: dict[str, int], grp_counts: dict[str, int]) -> None:
+        self.fig.clear()
+        if not dp_counts and not grp_counts:
+            self.canvas.draw()
+            return
+        ax1 = self.fig.add_subplot(211)
+        names = list(dp_counts)
+        vals = [dp_counts[n] for n in names]
+        cols = [self.colors.get(n, "#808080") for n in names]
+        ax1.bar(names, vals, color=cols)
+        ax1.set_title("Data Points per Class")
+        ax1.tick_params(axis='x', rotation=45)
+
+        ax2 = self.fig.add_subplot(212)
+        names_g = list(grp_counts)
+        vals_g = [grp_counts[n] for n in names_g]
+        cols_g = [self.colors.get(n, "#808080") for n in names_g]
+        ax2.bar(names_g, vals_g, color=cols_g)
+        ax2.set_title("Groups per Class")
+        ax2.tick_params(axis='x', rotation=45)
+
+        self.fig.tight_layout()
+        self.canvas.draw()


### PR DESCRIPTION
## Summary
- add `StatsTab` widget to visualize CSV label distributions
- integrate Stats tab into main UI
- automatically load latest export into stats after exporting

## Testing
- `python -m py_compile main_gui_v2.py stats_tab.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841935812ac832dbbc61bbee019c29a