### PR TITLE
Add dataset rebuild tab

### DIFF
--- a/labels.py
+++ b/labels.py
@@ -1,0 +1,20 @@
+from typing import Dict
+
+ANOMALY_TYPES: Dict[str, Dict[str, str | int]] = {
+    "normal": {"score": 0,  "color": "#00FF00"},
+    "depression": {"score": 4, "color": "#FF0000"},
+    "cover": {"score": 2, "color": "#FFA500"},
+    "cobble road/ traditional road": {"score": 1, "color": "#FFFF00"},
+    "transverse grove": {"score": 1, "color": "#008000"},
+    "gravel road": {"score": 4, "color": "#FAF2A1"},
+    "cracked / irregular pavement and aspahlt": {"score": 2, "color": "#E06D06"},
+    "bump": {"score": 1, "color": "#54F2F2"},
+    "uneven/repaired asphalt road": {"score": 1, "color": "#A30B37"},
+    "Damaged pavemant / asphalt road": {"score": 4, "color": "#2B15AA"},
+}
+UNKNOWN_ID = 99
+UNKNOWN_NAME = "unknown"
+UNKNOWN_COLOR = "#808080"
+
+LABEL_IDS = {name: i + 1 for i, name in enumerate(ANOMALY_TYPES)}
+

--- a/main_gui_v2.py
+++ b/main_gui_v2.py
@@ -142,6 +142,7 @@ try:
     from progress_ui import ProgressWindow
     from videopc_widget import VideoPointCloudTab
     from stats_tab import StatsTab
+    from rebuild_tab import RebuildTab
     from training_tab import TrainingTab, HybridNet, ResNet1D
 except ModuleNotFoundError:
     print("[FATAL] ROS 2-Python-Pakete nicht gefunden. Bitte ROS 2 installieren & sourcen.")
@@ -184,19 +185,10 @@ DEFAULT_OVERRIDES: dict[str, np.ndarray] = {
 # ===========================================================================
 # Label-Mapping
 # ===========================================================================
-ANOMALY_TYPES: Dict[str, Dict[str, str | int]] = {
-    "normal": {"score": 0,  "color": "#00FF00"},
-    "depression": {"score": 4, "color": "#FF0000"},
-    "cover": {"score": 2, "color": "#FFA500"},
-    "cobble road/ traditional road": {"score": 1, "color": "#FFFF00"},
-    "transverse grove": {"score": 1, "color": "#008000"},
-    "gravel road": {"score": 4, "color": "#FAF2A1"},
-    "cracked / irregular pavement and aspahlt": {"score": 2, "color": "#E06D06"},
-    "bump": {"score": 1, "color": "#54F2F2"},
-    "uneven/repaired asphalt road": {"score": 1, "color": "#A30B37"},
-    "Damaged pavemant / asphalt road": {"score": 4, "color": "#2B15AA"},
-}
-UNKNOWN_ID, UNKNOWN_NAME, UNKNOWN_COLOR = 99, "unknown", "#808080"
+from labels import (
+    ANOMALY_TYPES, LABEL_IDS as GLOBAL_LABEL_IDS,
+    UNKNOWN_ID, UNKNOWN_NAME, UNKNOWN_COLOR,
+)
 
 # ===========================================================================
 # Dataclass IMU
@@ -956,7 +948,7 @@ class EditLabelCmd(QUndoCommand):
 # Main-Window
 # ===========================================================================
 class MainWindow(QMainWindow):
-    LABEL_IDS = {name: i + 1 for i, name in enumerate(ANOMALY_TYPES)}
+    LABEL_IDS = GLOBAL_LABEL_IDS
 
     def __init__(self) -> None:
         super().__init__()
@@ -1089,6 +1081,10 @@ class MainWindow(QMainWindow):
         colors[UNKNOWN_NAME] = UNKNOWN_COLOR
         self.tab_stats = StatsTab(colors, UNKNOWN_NAME)
         self.tabs.addTab(self.tab_stats, "Stats")
+
+        # ------------------------------------------------------ Rebuild
+        self.tab_rebuild = RebuildTab()
+        self.tabs.addTab(self.tab_rebuild, "Rebuild")
 
         # ------------------------------------------------------ Train
         self.tab_train = TrainingTab(MainWindow.LABEL_IDS, UNKNOWN_ID)

--- a/rebuild_tab.py
+++ b/rebuild_tab.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+from labels import (
+    ANOMALY_TYPES, LABEL_IDS,
+    UNKNOWN_ID, UNKNOWN_NAME, UNKNOWN_COLOR,
+)
+
+import pandas as pd
+from matplotlib.widgets import SpanSelector
+from matplotlib.figure import Figure
+from PyQt5.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
+    QFileDialog, QComboBox, QTabWidget
+)
+from PyQt5.QtGui import QPixmap
+from PyQt5.QtCore import Qt
+import shutil
+
+try:
+    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+except Exception:
+    from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+
+# ---------------------------------------------------------------------------
+class RebuildTab(QWidget):
+    """Load exported CSV data to adjust labels and view peak images."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.folder: Path | None = None
+        self.csv_dfs: Dict[str, pd.DataFrame] = {}
+        self.current_csv: str | None = None
+        self.current_span: tuple[float, float] | None = None
+
+        vbox = QVBoxLayout(self)
+        hl = QHBoxLayout()
+        hl.addWidget(QLabel("Folder:"))
+        self.lbl_folder = QLabel("-")
+        hl.addWidget(self.lbl_folder)
+        self.btn_browse = QPushButton("Browse…")
+        self.btn_browse.clicked.connect(self._browse)
+        hl.addWidget(self.btn_browse)
+        hl.addStretch()
+        vbox.addLayout(hl)
+
+        self.tabs = QTabWidget()
+        vbox.addWidget(self.tabs, 1)
+
+        # --------------------------- Data tab
+        w_data = QWidget()
+        v_data = QVBoxLayout(w_data)
+        self.cmb_csv = QComboBox()
+        self.cmb_csv.currentTextChanged.connect(self._select_csv)
+        v_data.addWidget(self.cmb_csv)
+
+        self.fig = Figure(layout="constrained")
+        self.canvas = FigureCanvas(self.fig)
+        v_data.addWidget(self.canvas, 1)
+
+        ctl = QHBoxLayout()
+        ctl.addWidget(QLabel("Label:"))
+        self.cmb_label = QComboBox()
+        self.cmb_label.addItems(list(ANOMALY_TYPES))
+        ctl.addWidget(self.cmb_label)
+        self.btn_add = QPushButton("Add")
+        self.btn_add.clicked.connect(self._add_label)
+        ctl.addWidget(self.btn_add)
+        self.btn_del = QPushButton("Delete")
+        self.btn_del.clicked.connect(self._del_label)
+        ctl.addWidget(self.btn_del)
+        self.btn_save = QPushButton("Save")
+        self.btn_save.clicked.connect(self._save_csv)
+        ctl.addWidget(self.btn_save)
+        self.btn_export = QPushButton("Export…")
+        self.btn_export.clicked.connect(self._export)
+        ctl.addWidget(self.btn_export)
+        ctl.addStretch()
+        v_data.addLayout(ctl)
+
+        self.tabs.addTab(w_data, "Data")
+
+        # --------------------------- Peak image tab
+        w_peak = QWidget()
+        v_peak = QVBoxLayout(w_peak)
+        self.cmb_peak = QComboBox()
+        self.cmb_peak.currentTextChanged.connect(self._select_peak)
+        v_peak.addWidget(self.cmb_peak)
+        self.lbl_peak = QLabel("No image")
+        self.lbl_peak.setAlignment(Qt.AlignCenter)
+        v_peak.addWidget(self.lbl_peak, 1)
+        self.tabs.addTab(w_peak, "Peaks")
+
+    # ------------------------------------------------------------------ browsing
+    def _browse(self) -> None:
+        path = QFileDialog.getExistingDirectory(self, "Select export folder", str(Path.home()))
+        if path:
+            self.load_folder(Path(path))
+
+    def load_folder(self, folder: Path) -> None:
+        self.folder = folder
+        self.lbl_folder.setText(str(folder))
+        self.csv_dfs.clear()
+        self.cmb_csv.clear()
+        for csv in sorted(folder.glob("*.csv")):
+            if csv.name.endswith("_track.csv"):
+                continue
+            self.cmb_csv.addItem(csv.name, csv)
+        # peaks
+        self.cmb_peak.clear()
+        peak_dir = folder / "peaks"
+        if peak_dir.is_dir():
+            for sub in sorted(peak_dir.iterdir()):
+                if sub.is_dir():
+                    self.cmb_peak.addItem(sub.name, sub)
+
+    # ------------------------------------------------------------------ CSV logic
+    def _select_csv(self, name: str) -> None:
+        path = self.cmb_csv.currentData()
+        if not path:
+            return
+        df = pd.read_csv(path)
+        self.csv_dfs[name] = df
+        self.current_csv = name
+        self._draw(df)
+
+    def _draw(self, df: pd.DataFrame) -> None:
+        self.fig.clear()
+        ax = self.fig.add_subplot(111)
+        ax.plot(df["time"], df["accel_x"], label="accel_x")
+        ax.plot(df["time"], df["accel_y"], label="accel_y")
+        ax.plot(df["time"], df["accel_z"], label="accel_z")
+        self._restore_labels(ax, df)
+        self.span = SpanSelector(ax, self._span, "horizontal", useblit=True,
+                                 props=dict(alpha=.3, facecolor="#ff8888"))
+        ax.set_xlabel("time [s]")
+        ax.set_ylabel("m/s²")
+        ax.legend(fontsize="x-small")
+        self.canvas.draw_idle()
+
+    def _restore_labels(self, ax, df: pd.DataFrame) -> None:
+        last = UNKNOWN_NAME
+        start = None
+        prev = None
+        for t, lbl in zip(df["time"], df["label_name"]):
+            if lbl != last:
+                if last != UNKNOWN_NAME and start is not None:
+                    color = ANOMALY_TYPES[last]["color"]
+                    ax.axvspan(start, prev, color=color, alpha=0.2)
+                start = t
+                last = lbl
+            prev = t
+        if last != UNKNOWN_NAME and start is not None and prev is not None:
+            color = ANOMALY_TYPES[last]["color"]
+            ax.axvspan(start, prev, color=color, alpha=0.2)
+
+    def _span(self, xmin: float, xmax: float) -> None:
+        self.current_span = (xmin, xmax)
+
+    def _add_label(self) -> None:
+        if not self.current_csv or not self.current_span:
+            return
+        df = self.csv_dfs[self.current_csv]
+        xmin, xmax = self.current_span
+        if xmax <= xmin:
+            return
+        lname = self.cmb_label.currentText()
+        lid = LABEL_IDS[lname]
+        mask = (df["time"] >= xmin) & (df["time"] <= xmax)
+        df.loc[mask, ["label_id", "label_name"]] = [lid, lname]
+        self._draw(df)
+
+    def _del_label(self) -> None:
+        if not self.current_csv or not self.current_span:
+            return
+        df = self.csv_dfs[self.current_csv]
+        xmin, xmax = self.current_span
+        if xmax <= xmin:
+            return
+        mask = (df["time"] >= xmin) & (df["time"] <= xmax)
+        df.loc[mask, ["label_id", "label_name"]] = [UNKNOWN_ID, UNKNOWN_NAME]
+        self._draw(df)
+
+    def _save_csv(self) -> None:
+        if not self.current_csv:
+            return
+        path = self.cmb_csv.currentData()
+        df = self.csv_dfs[self.current_csv]
+        df.to_csv(path, index=False)
+
+    def _export(self) -> None:
+        if not self.folder:
+            return
+        dest = QFileDialog.getExistingDirectory(
+            self, "Select target folder", str(self.folder.parent)
+        )
+        if not dest:
+            return
+        dst = Path(dest)
+        dst.mkdir(parents=True, exist_ok=True)
+        for item in self.folder.iterdir():
+            if item.is_dir():
+                shutil.copytree(item, dst / item.name, dirs_exist_ok=True)
+            else:
+                shutil.copy2(item, dst / item.name)
+
+    # ------------------------------------------------------------------ peaks
+    def _select_peak(self, name: str) -> None:
+        path = self.cmb_peak.currentData()
+        if not path:
+            return
+        imgs = sorted(path.glob("*.png"))
+        if imgs:
+            pix = QPixmap(str(imgs[0]))
+            self.lbl_peak.setPixmap(pix.scaled(640, 480, Qt.KeepAspectRatio, Qt.SmoothTransformation))
+        else:
+            self.lbl_peak.setText("No image")
+            self.lbl_peak.setPixmap(QPixmap())


### PR DESCRIPTION
## Summary
- create `RebuildTab` for editing exported CSV data
- integrate the new tab into the main GUI
- centralize label definitions in new `labels.py`
- allow exporting rebuilt datasets

## Testing
- `python -m py_compile main_gui_v2.py rebuild_tab.py videopc_widget.py stats_tab.py imu_csv_export_v2.py progress_ui.py map_widget.py training_tab.py labels.py`


------
https://chatgpt.com/codex/tasks/task_e_684951754e68832d988122b2058cc0ab