### PR TITLE
Fix window not maximizing

### DIFF
--- a/main_gui_v2.py
+++ b/main_gui_v2.py
@@ -1019,6 +1019,9 @@ class MainWindow(QMainWindow):
         # Restore persisted window state
         self._restore_settings()
 
+        # Ensure window starts maximized after restoring settings
+        QTimer.singleShot(0, self.showMaximized)
+
     # ------------------------------------------------------------------ UI
     def _build_ui(self) -> None:
         central = QWidget()
@@ -2264,7 +2267,6 @@ class MainWindow(QMainWindow):
 def main() -> None:
     app = QApplication(sys.argv)
     win = MainWindow()
-    win.showMaximized()
     sys.exit(app.exec())
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure main window starts maximized after restoring settings

## Testing
- `python3 -m py_compile main_gui_v2.py progress_ui.py relabel_csv_gui.py map_widget.py segments_tab.py stats_tab.py training_tab.py labels.py iso_weighting.py rebuild_tab.py imu_csv_export_v2.py videopc_widget.py`


------
https://chatgpt.com/codex/tasks/task_e_684e991bde98832dbb28a9a4444c639b